### PR TITLE
chore: fix numberString

### DIFF
--- a/src/util/plot.ts
+++ b/src/util/plot.ts
@@ -67,8 +67,9 @@ export const numberString = (number: number): string => {
     const exponential = Math.abs(number) < 0.0001 && number != 0
     let result = exponential ? number.toExponential(6) : number.toPrecision(6)
     while ((result.endsWith("0") || result.endsWith(".")) && !exponential) {
+        const isPeriod = result.endsWith(".");
         result = result.slice(0, result.length - 1)
-        if (result == "0") {
+        if (result == "0" || isPeriod) {
             break
         }
     }


### PR DESCRIPTION
Hi, thanks for the useful utility.  This PR fixes `numberString()`.

`numberString(10.0)` must be `"10"` but actually it returns `"1"` since it doesn't treat `'.'` as a terminator.
